### PR TITLE
Added optional category to feeds, picked up from OPML

### DIFF
--- a/RSSAtomKit/RSSFeed.h
+++ b/RSSAtomKit/RSSFeed.h
@@ -65,6 +65,11 @@ extern NSString *const kRSSFeedRSSNameSpace;
 @property (nonatomic, strong, readonly) NSString *feedDescription;
 
 /**
+ Optional feed category, picked up from nested outline elements in an OMPL file
+ */
+@property (nonatomic, strong, readonly) NSString *feedCategory;
+
+/**
  Creates and returns a RSSFeed object from an ONOXMLDocument
  
  @param xmlDocument the xml document that will be parsed


### PR DESCRIPTION
Found an old OPML file and saw that outline elements can be nested, to create feed categories. Makes the feed selection in the onboarding process very nice, with categories (implemented, but not checked in yet, since it needs something like this).

What do you think?
